### PR TITLE
Add spectral freeze/hold effect (#11)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,13 +8,13 @@
 
 ## Open Issues Summary
 
-**7 open issues** across 7 phases (22 completed)
+**6 open issues** across 7 phases (23 completed)
 
 | Priority | Count | Issues |
 |----------|-------|--------|
 | :red_circle: Critical | 0 | &mdash; |
 | :yellow_circle: High | 0 | &mdash; |
-| :green_circle: Medium | 4 | #11, #12, #23, #24 |
+| :green_circle: Medium | 3 | #12, #23, #24 |
 | :large_blue_circle: Low | 3 | #10, #27, #28 |
 
 ---
@@ -45,6 +45,7 @@ The following capabilities already exist in the codebase:
 - **Spectrum analyzer** &mdash; `<SpectrumAnalyzer />` SolidJS component with WebGL rendering, log frequency axis (20Hz&ndash;20kHz), dB magnitude axis (-90&ndash;0 dB), line/filled/bars render modes, peak hold with decay, responsive resize, graceful WebGL fallback
 - **Control panel** &mdash; `<ControlPanel />` SolidJS component with source selector (Live/Oscillator/Noise/File), oscillator waveform+frequency controls, noise type selector, WAV file picker via native dialog + seek slider + loop toggle, engine start/stop button, master gain slider
 - **Parametric EQ** &mdash; `ParametricEq` spectral transform with `EqBand` (frequency, gain_db, q, band_type) and `BandType` enum (Peak, LowShelf, HighShelf); smooth bell curves for Peak, sigmoid transitions for shelves; `TransformSpec::ParametricEq` variant with serde support and TypeScript bindings
+- **Spectral freeze** &mdash; `SpectralFreeze` implementing `SpectralTransform` with magnitude+phase capture on activation, continuous frozen spectrum output, smooth crossfade on toggle (~75ms, linear interpolation in complex domain), `TransformSpec::SpectralFreeze { frozen: bool }` variant with serde support
 - **Transform panel** &mdash; `<TransformPanel />` SolidJS component with transform type selector (Identity, LowPass, HighPass, BandPass, Gain, ParametricEq); per-transform parameter controls (cutoff frequency, band range, gain factor); parametric EQ per-band controls (frequency, gain dB, Q, band type) with add/remove; transform chain mode with add/remove/reorder multiple transforms; all changes immediately sent to engine via `set_transform` Tauri command
 - **Waveform oscilloscope** &mdash; `WaveformSnapshot` struct with rolling time-domain sample buffer; `get_waveform` Tauri command with drain-to-latest polling; `<WaveformDisplay />` SolidJS component with WebGL rendering, zero-crossing trigger for stable display, amplitude axis (-1 to +1), time axis (ms), responsive resize; green oscilloscope color scheme; stacked layout with spectrum analyzer
 - **Error handling &amp; logging** &mdash; `thiserror`-based error enums (`CoreError`, `AudioIoError`, `EngineError`, `FileIoError`) across all crates; no `String` error types in public APIs; `tracing` instrumentation at engine lifecycle, parameter changes, and error paths; Tauri commands convert `EngineError` to user-friendly strings
@@ -102,13 +103,13 @@ The following capabilities already exist in the codebase:
 |---|-------|----------|--------|--------------|
 | #9 | ~~Add parametric EQ as SpectralTransform~~ | :white_check_mark: Done | ~2 days | &mdash; |
 | #10 | Add spectral delay effect | :large_blue_circle: Low | ~2 days | &mdash; |
-| #11 | Add spectral freeze/hold effect | :green_circle: Medium | ~1 day | &mdash; |
+| #11 | ~~Add spectral freeze/hold effect~~ | :white_check_mark: Done | ~1 day | &mdash; |
 | #12 | Add pitch shifting via spectral bin rotation | :green_circle: Medium | ~2 days | &mdash; |
 
 **Key deliverables:**
 - ~~`ParametricEq` with Peak/LowShelf/HighShelf bands~~ :white_check_mark:
 - `SpectralDelay` with per-band ring buffers
-- `SpectralFreeze` with smooth crossfade toggle
+- ~~`SpectralFreeze` with smooth crossfade toggle~~ :white_check_mark:
 - `PitchShift` with linear interpolation for fractional shifts
 
 ---
@@ -252,7 +253,7 @@ App shell and engine commands done. Moving to streaming and source commands:
 
 These can proceed independently alongside the critical path:
 
-- **DSP track:** ~~#9 (Parametric EQ)~~, #11 (Freeze), #12 (Pitch shift)
+- **DSP track:** ~~#9 (Parametric EQ)~~, ~~#11 (Freeze)~~, #12 (Pitch shift)
 - **File I/O track:** ~~#6~~, ~~#7~~ (WAV read/write) :white_check_mark:
 - **Polish track:** ~~#25~~, ~~#26~~ (error handling, CI) :white_check_mark:
 
@@ -305,7 +306,7 @@ These can proceed independently alongside the critical path:
 |-------|-------|-----------|
 | 21 | #23 Preset system | UX polish |
 | 22 | #24 Audio export | Render to file |
-| 23 | #11 Spectral freeze | Creative effect |
+| ~~23~~ | ~~#11 Spectral freeze~~ | ~~Creative effect~~ :white_check_mark: |
 | 24 | #12 Pitch shifting | Creative effect |
 
 ### Batch 7: Future (Week 8+)
@@ -325,12 +326,12 @@ These can proceed independently alongside the critical path:
 |-------|-------|----------|------|--------|-----|------|
 | 1 &mdash; Sound Gen | 4 | 0 | 0 | 0 | 0 | 4 |
 | 2 &mdash; File I/O | 3 | 0 | 0 | 0 | 0 | 3 |
-| 3 &mdash; DSP | 4 | 0 | 0 | 2 | 1 | 1 |
+| 3 &mdash; DSP | 4 | 0 | 0 | 1 | 1 | 2 |
 | 4 &mdash; Tauri | 4 | 0 | 0 | 0 | 0 | 4 |
 | 5 &mdash; UI | 5 | 0 | 0 | 0 | 0 | 5 |
 | 6 &mdash; Workflow | 3 | 0 | 0 | 2 | 0 | 1 |
 | 7 &mdash; Polish/Web | 6 | 0 | 0 | 0 | 2 | 4 |
-| **Total** | **29** | **0** | **0** | **4** | **3** | **22** |
+| **Total** | **29** | **0** | **0** | **3** | **3** | **23** |
 
 ---
 
@@ -351,6 +352,7 @@ These can proceed independently alongside the critical path:
 ## Changelog
 
 ### 2026-02-11
+- **Completed #11** (spectral freeze/hold effect) &mdash; created `SpectralFreeze` struct implementing `SpectralTransform` in `crates/core/src/transform.rs`; when activated (`frozen = true`), captures current spectral frame magnitudes and phases; while frozen, outputs captured spectrum instead of live input; smooth crossfade on toggle (~75ms duration) via linear interpolation in complex domain between live and frozen spectra; `crossfade_pos` ramps from 0.0 (fully live) to 1.0 (fully frozen) at a rate computed from `sample_rate / hop_size`; captured data released after unfreezing completes; `set_frozen(bool)` and `is_frozen()` accessors; `TransformSpec::SpectralFreeze { frozen: bool }` variant in `crates/engine/src/params.rs` with serde support; wired into `build_transform()` in `processor.rs` passing `sample_rate` and `hop_size` for crossfade timing; re-exported `SpectralFreeze` from `fourier-core` and `fourier-engine` crate roots; 8 new unit tests in `fourier-core`: freeze captures spectrum on activation, frozen output is stable, unfrozen passes through, crossfade is smooth (monotonically increasing), toggle off crossfades back (monotonically decreasing), getters, name, empty spectrum no panic; 4 new serde roundtrip tests in `fourier-engine`: frozen/unfrozen variants, in-chain, param message; 2 engine integration tests: freeze produces output with oscillator source, rapid freeze toggle does not panic; all 225 tests pass
 - **Completed #4** (additive synthesis module) &mdash; created `crates/core/src/additive.rs` with `Partial` struct (`frequency`, `amplitude`, `phase` fields, serde `Serialize`/`Deserialize`), `AdditiveSynth` struct with `Vec<PartialState>` runtime state and `sample_rate`, `generate(&mut self, output: &mut [f32])` method that sums sine wave partials with per-partial phase tracking (wraps at 2&pi; to prevent precision loss, continuous across calls), `harmonic_series(fundamental, num_harmonics)` helper generating partials at f, 2f, 3f, &hellip; with 1/n amplitude rolloff; `num_partials()` and `sample_rate()` getters; re-exported `Partial`, `AdditiveSynth`, `harmonic_series` from `fourier-core` crate root; moved `Partial` ownership from `fourier-engine` params to `fourier-core` additive module &mdash; engine re-exports via `pub use fourier_core::Partial`; refactored engine `AdditiveSource` to delegate to `fourier_core::AdditiveSynth` instead of inline implementation; re-exported `AdditiveSynth` from `fourier-engine` crate root; 19 new unit tests in `fourier-core`: single partial peak frequency, single partial matches sine oscillator, multiple partials have expected peaks, summing N partials produces correct output, harmonic series correct frequencies/amplitudes/zero harmonics/zero phase/spectral peaks, phase continuous across generate calls, phase continuous for multiple partials, empty partials silence, empty buffer no-op, zero amplitude silence, num_partials getter, sample_rate getter, Partial serde roundtrip, Vec&lt;Partial&gt; serde roundtrip; 2 doc tests (AdditiveSynth example, harmonic_series example); all 196 existing tests pass; completes Phase 1 (Sound Generation) with all 4 issues done
 - **Completed #51** (review and optimize CI workflow) &mdash; removed nightly Rust toolchain from the CI matrix for build, clippy, and test jobs; project pins Rust 1.93.0 via `rust-toolchain.toml` so nightly runs provided no meaningful signal while doubling CI cost; removed `needs: build` dependency from clippy and test jobs so all four main jobs (fmt, build, clippy, test) run in parallel; reduced CI from 8 jobs to 5 (fmt, build, clippy, test, deny); removed `fail-fast: false` and `continue-on-error` (no longer needed without matrix); kept `Swatinem/rust-cache@v2` for cargo build caching; deny job unchanged on ubuntu-latest; simplified job names (no toolchain suffix)
 - **Completed #3** (noise generators: white, pink) &mdash; created `crates/core/src/noise.rs` with `NoiseGenerator` struct and `NoiseType` enum (`White`, `Pink`); `NoiseGenerator::new(noise_type, amplitude, sample_rate)` constructor with `generate(&mut self, output: &mut [f32])` buffer-filling method; white noise via xorshift64 PRNG (deterministic, no external dependencies) mapping upper 24 bits to `[-1.0, +1.0)` float range; pink noise via Voss-McCartney algorithm with 16 octave rows, trailing-zeros scheduling for per-row update timing, normalization factor `1/(NUM_ROWS+1)`, and running-sum accumulator for O(1) per-sample generation; PRNG extracted to module-level `prng_next_u64`/`prng_next_f32` free functions to satisfy borrow checker when iterating pink rows; getter/setter methods (`set_amplitude`, `set_noise_type`, `amplitude()`, `noise_type()`, `sample_rate()`) with `const` where possible; serde `Serialize`/`Deserialize` on `NoiseType`; re-exported `NoiseGenerator` and `NoiseType` from `fourier-core` crate root; refactored `fourier-engine` to use `fourier_core::NoiseGenerator` instead of duplicating white/pink noise implementations &mdash; replaced `WhiteNoiseSource` and `PinkNoiseSource` structs in `crates/engine/src/source.rs` with unified `NoiseSource` wrapper delegating to `NoiseGenerator`; `NoiseType` in `crates/engine/src/params.rs` changed from local enum to `pub use fourier_core::NoiseType` re-export; 15 new unit tests in `fourier-core`: white noise energy, amplitude bounds, approximately flat spectrum (averaged over 32 FFT frames with octave band comparison), pink noise energy, amplitude bounds, approximately &minus;3dB/octave rolloff (averaged over 64 FFT frames across 4 octave pairs), pink more-low-than-high total energy, white-flatter-than-pink comparative spectral analysis, property getters, noise type switching, amplitude energy scaling (`0.25&sup2; = 0.0625` ratio verification), zero amplitude silence, empty buffer no-op, serde roundtrip, deterministic output; all 178 existing tests pass

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -21,5 +21,7 @@ pub use noise::{NoiseGenerator, NoiseType};
 pub use oscillator::{Oscillator, WaveformType};
 pub use overlap_add::OverlapAddProcessor;
 pub use spectral::{detect_peaks, SpectralPeak};
-pub use transform::{BandType, EqBand, FrequencyBin, ParametricEq, SpectralTransform};
+pub use transform::{
+    BandType, EqBand, FrequencyBin, ParametricEq, SpectralFreeze, SpectralTransform,
+};
 pub use window::{WindowFunction, WindowType};

--- a/crates/core/src/transform.rs
+++ b/crates/core/src/transform.rs
@@ -271,6 +271,128 @@ impl SpectralTransform for ParametricEq {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Spectral Freeze
+// ---------------------------------------------------------------------------
+
+/// Spectral freeze: captures the current spectrum and continuously
+/// resynthesizes it as a sustained sound.
+///
+/// When activated (`frozen = true`), the transform captures the current
+/// spectral frame (magnitudes + phases). While frozen, it outputs the
+/// captured spectrum instead of the live input, with a smooth crossfade
+/// on toggle to avoid clicks.
+///
+/// This is a **spectral snapshot** freeze: the exact magnitudes and phases
+/// from the capture moment are replayed each frame. Because the phases are
+/// static, the resulting tone has a characteristic "metallic" or "resonant"
+/// quality rather than a natural pad-like sustain.
+pub struct SpectralFreeze {
+    /// Whether the freeze effect is active.
+    frozen: bool,
+    /// Whether a spectrum has been captured for the current freeze activation.
+    has_captured: bool,
+    /// Captured spectrum (magnitudes) from the moment of freeze activation.
+    captured_magnitudes: Vec<f32>,
+    /// Captured spectrum (phases) from the moment of freeze activation.
+    captured_phases: Vec<f32>,
+    /// Current crossfade position: 0.0 = fully live, 1.0 = fully frozen.
+    crossfade_pos: f32,
+    /// Crossfade increment per frame, computed from sample rate and FFT/hop sizes.
+    /// Targets ~75ms crossfade duration.
+    crossfade_step: f32,
+}
+
+impl SpectralFreeze {
+    /// Create a new spectral freeze effect.
+    ///
+    /// - `frozen`: initial freeze state.
+    /// - `sample_rate`: audio sample rate in Hz.
+    /// - `hop_size`: OLA hop size (frames between successive FFT windows).
+    pub fn new(frozen: bool, sample_rate: f32, hop_size: usize) -> Self {
+        // Target crossfade duration: ~75ms.
+        // Frames per second = sample_rate / hop_size.
+        // Number of frames in 75ms = (sample_rate / hop_size) * 0.075.
+        // Step per frame = 1.0 / num_frames.
+        let frames_per_sec = sample_rate / hop_size as f32;
+        let crossfade_frames = (frames_per_sec * 0.075).max(1.0);
+        let crossfade_step = 1.0 / crossfade_frames;
+
+        Self {
+            frozen,
+            has_captured: false,
+            captured_magnitudes: Vec::new(),
+            captured_phases: Vec::new(),
+            crossfade_pos: if frozen { 1.0 } else { 0.0 },
+            crossfade_step,
+        }
+    }
+
+    /// Set the freeze state. When transitioning to frozen, the next call
+    /// to `process` will capture the spectrum.
+    pub const fn set_frozen(&mut self, frozen: bool) {
+        if frozen && !self.frozen {
+            self.has_captured = false;
+        }
+        self.frozen = frozen;
+    }
+
+    /// Returns whether the freeze is currently active.
+    pub const fn is_frozen(&self) -> bool {
+        self.frozen
+    }
+}
+
+impl SpectralTransform for SpectralFreeze {
+    fn process(&mut self, spectrum: &mut [Complex<f32>], _sample_rate: f32, _fft_size: usize) {
+        // Update crossfade position toward target.
+        let target = if self.frozen { 1.0 } else { 0.0 };
+        if (self.crossfade_pos - target).abs() > f32::EPSILON {
+            if self.crossfade_pos < target {
+                self.crossfade_pos = (self.crossfade_pos + self.crossfade_step).min(1.0);
+            } else {
+                self.crossfade_pos = (self.crossfade_pos - self.crossfade_step).max(0.0);
+            }
+        }
+
+        // Capture spectrum when transitioning to frozen (first frame after activation).
+        if self.frozen && !self.has_captured {
+            self.captured_magnitudes = spectrum.iter().map(|c| c.norm()).collect();
+            self.captured_phases = spectrum.iter().map(|c| c.arg()).collect();
+            self.has_captured = true;
+        }
+
+        // If we have no captured data yet, pass through.
+        if !self.has_captured {
+            return;
+        }
+
+        // If fully live (crossfade = 0), nothing to do.
+        if self.crossfade_pos < f32::EPSILON {
+            // When unfrozen and crossfade complete, release captured data.
+            if !self.frozen {
+                self.captured_magnitudes.clear();
+                self.captured_phases.clear();
+                self.has_captured = false;
+            }
+            return;
+        }
+
+        // Interpolate between live spectrum and captured spectrum.
+        let mix = self.crossfade_pos;
+        for (i, bin) in spectrum.iter_mut().enumerate() {
+            let frozen_bin =
+                FrequencyBin::from_polar(self.captured_magnitudes[i], self.captured_phases[i]);
+            // Linear interpolation in complex domain for smooth crossfade.
+            *bin = *bin * (1.0 - mix) + frozen_bin * mix;
+        }
+    }
+
+    fn name(&self) -> &'static str {
+        "Spectral Freeze"
+    }
+}
+
 /// Chain of transforms applied in sequence.
 pub struct TransformChain {
     transforms: Vec<Box<dyn SpectralTransform>>,
@@ -685,5 +807,237 @@ mod tests {
         for bin in &spectrum {
             assert!((bin.re - 1.0).abs() < 1e-6);
         }
+    }
+
+    // -----------------------------------------------------------------------
+    // SpectralFreeze tests
+    // -----------------------------------------------------------------------
+
+    /// Helper: create a known spectrum with distinct magnitudes per bin.
+    fn make_known_spectrum(num_bins: usize) -> Vec<Complex<f32>> {
+        (0..num_bins)
+            .map(|i| {
+                let mag = (i as f32 + 1.0) * 0.1;
+                let phase = (i as f32) * 0.5;
+                FrequencyBin::from_polar(mag, phase)
+            })
+            .collect()
+    }
+
+    #[test]
+    fn freeze_captures_spectrum_on_activation() {
+        let sample_rate = 44100.0;
+        let fft_size = 1024;
+        let hop_size = 512;
+        let num_bins = fft_size / 2 + 1;
+
+        // Create a freeze that starts frozen.
+        let mut freeze = SpectralFreeze::new(true, sample_rate, hop_size);
+        let mut spectrum = make_known_spectrum(num_bins);
+        let original_mags: Vec<f32> = spectrum.iter().map(|c| c.norm()).collect();
+
+        // Process once to capture.
+        freeze.process(&mut spectrum, sample_rate, fft_size);
+
+        // After enough frames to fully crossfade, the output should match captured.
+        // Run many frames to complete the crossfade.
+        for _ in 0..200 {
+            // Feed a different spectrum (zeros) — freeze should ignore it.
+            let mut zero_input = vec![Complex::new(0.0, 0.0); num_bins];
+            freeze.process(&mut zero_input, sample_rate, fft_size);
+
+            // Once fully frozen, output should match the captured spectrum.
+            if (freeze.crossfade_pos - 1.0).abs() < f32::EPSILON {
+                for (i, bin) in zero_input.iter().enumerate() {
+                    let expected_mag = original_mags[i];
+                    let actual_mag = bin.norm();
+                    assert!(
+                        (actual_mag - expected_mag).abs() < 0.01,
+                        "bin {i}: expected mag {expected_mag:.4}, got {actual_mag:.4}"
+                    );
+                }
+                return;
+            }
+        }
+
+        panic!("crossfade did not complete");
+    }
+
+    #[test]
+    fn freeze_output_is_stable() {
+        let sample_rate = 44100.0;
+        let fft_size = 1024;
+        let hop_size = 512;
+        let num_bins = fft_size / 2 + 1;
+
+        let mut freeze = SpectralFreeze::new(true, sample_rate, hop_size);
+
+        // Capture a known spectrum.
+        let mut frame = make_known_spectrum(num_bins);
+        freeze.process(&mut frame, sample_rate, fft_size);
+
+        // Run until fully frozen.
+        for _ in 0..200 {
+            frame = vec![Complex::new(0.0, 0.0); num_bins];
+            freeze.process(&mut frame, sample_rate, fft_size);
+        }
+
+        // Capture the frozen output.
+        let mut frozen_a = vec![Complex::new(0.0, 0.0); num_bins];
+        freeze.process(&mut frozen_a, sample_rate, fft_size);
+
+        let mut frozen_b = vec![Complex::new(0.0, 0.0); num_bins];
+        freeze.process(&mut frozen_b, sample_rate, fft_size);
+
+        // Both should be identical (stable output).
+        for (i, (a, b)) in frozen_a.iter().zip(&frozen_b).enumerate() {
+            assert!(
+                (a.re - b.re).abs() < 1e-6 && (a.im - b.im).abs() < 1e-6,
+                "bin {i}: frozen output should be stable, got ({}, {}) vs ({}, {})",
+                a.re,
+                a.im,
+                b.re,
+                b.im
+            );
+        }
+    }
+
+    #[test]
+    fn freeze_unfrozen_passes_through() {
+        let sample_rate = 44100.0;
+        let fft_size = 1024;
+        let hop_size = 512;
+        let num_bins = fft_size / 2 + 1;
+
+        // Start unfrozen.
+        let mut freeze = SpectralFreeze::new(false, sample_rate, hop_size);
+
+        let original: Vec<Complex<f32>> = (0..num_bins)
+            .map(|i| Complex::new(i as f32 * 0.01, -(i as f32) * 0.005))
+            .collect();
+        let mut spectrum = original.clone();
+
+        freeze.process(&mut spectrum, sample_rate, fft_size);
+
+        // Should be pass-through (identical to input).
+        for (i, (orig, out)) in original.iter().zip(&spectrum).enumerate() {
+            assert!(
+                (orig.re - out.re).abs() < 1e-6 && (orig.im - out.im).abs() < 1e-6,
+                "bin {i}: unfrozen should pass through"
+            );
+        }
+    }
+
+    #[test]
+    fn freeze_crossfade_is_smooth() {
+        let sample_rate = 44100.0;
+        let fft_size = 1024;
+        let hop_size = 512;
+        let num_bins = fft_size / 2 + 1;
+
+        let mut freeze = SpectralFreeze::new(false, sample_rate, hop_size);
+
+        // Process a few frames unfrozen.
+        for _ in 0..5 {
+            let mut spectrum = make_known_spectrum(num_bins);
+            freeze.process(&mut spectrum, sample_rate, fft_size);
+        }
+
+        // Activate freeze.
+        freeze.set_frozen(true);
+
+        // Track crossfade values — they should monotonically increase.
+        let mut prev_pos = 0.0_f32;
+        for _ in 0..200 {
+            let mut spectrum = vec![Complex::new(0.0, 0.0); num_bins];
+            freeze.process(&mut spectrum, sample_rate, fft_size);
+
+            assert!(
+                freeze.crossfade_pos >= prev_pos - f32::EPSILON,
+                "crossfade should increase monotonically: {} -> {}",
+                prev_pos,
+                freeze.crossfade_pos
+            );
+            prev_pos = freeze.crossfade_pos;
+
+            if (freeze.crossfade_pos - 1.0).abs() < f32::EPSILON {
+                break;
+            }
+        }
+
+        assert!(
+            (freeze.crossfade_pos - 1.0).abs() < f32::EPSILON,
+            "crossfade should reach 1.0"
+        );
+    }
+
+    #[test]
+    fn freeze_toggle_off_crossfades_back() {
+        let sample_rate = 44100.0;
+        let fft_size = 1024;
+        let hop_size = 512;
+        let num_bins = fft_size / 2 + 1;
+
+        let mut freeze = SpectralFreeze::new(true, sample_rate, hop_size);
+
+        // Capture and complete crossfade to frozen.
+        for _ in 0..200 {
+            let mut spectrum = make_known_spectrum(num_bins);
+            freeze.process(&mut spectrum, sample_rate, fft_size);
+        }
+        assert!(
+            (freeze.crossfade_pos - 1.0).abs() < f32::EPSILON,
+            "should be fully frozen"
+        );
+
+        // Now unfreeze.
+        freeze.set_frozen(false);
+
+        // Crossfade should decrease back to 0.
+        let mut prev_pos = 1.0_f32;
+        for _ in 0..200 {
+            let mut spectrum = make_known_spectrum(num_bins);
+            freeze.process(&mut spectrum, sample_rate, fft_size);
+
+            assert!(
+                freeze.crossfade_pos <= prev_pos + f32::EPSILON,
+                "crossfade should decrease: {} -> {}",
+                prev_pos,
+                freeze.crossfade_pos
+            );
+            prev_pos = freeze.crossfade_pos;
+
+            if freeze.crossfade_pos < f32::EPSILON {
+                break;
+            }
+        }
+
+        assert!(
+            freeze.crossfade_pos < f32::EPSILON,
+            "crossfade should reach 0.0 after unfreezing"
+        );
+    }
+
+    #[test]
+    fn freeze_getters() {
+        let freeze = SpectralFreeze::new(true, 44100.0, 512);
+        assert!(freeze.is_frozen());
+
+        let freeze2 = SpectralFreeze::new(false, 44100.0, 512);
+        assert!(!freeze2.is_frozen());
+    }
+
+    #[test]
+    fn freeze_name() {
+        let freeze = SpectralFreeze::new(false, 44100.0, 512);
+        assert_eq!(freeze.name(), "Spectral Freeze");
+    }
+
+    #[test]
+    fn freeze_empty_spectrum_no_panic() {
+        let mut freeze = SpectralFreeze::new(true, 44100.0, 512);
+        let mut spectrum: Vec<Complex<f32>> = Vec::new();
+        // Should not panic on empty spectrum.
+        freeze.process(&mut spectrum, 44100.0, 0);
     }
 }

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -12,7 +12,9 @@ pub mod processor;
 pub mod source;
 
 pub use error::EngineError;
-pub use fourier_core::{AdditiveSynth, BandType, EqBand, NoiseGenerator, WaveformType};
+pub use fourier_core::{
+    AdditiveSynth, BandType, EqBand, NoiseGenerator, SpectralFreeze, WaveformType,
+};
 pub use params::{EngineParams, NoiseType, ParamMessage, Partial, SourceSpec, TransformSpec};
 pub use processor::{Engine, SpectralSnapshot, WaveformSnapshot};
 pub use source::{AudioBufferSource, AudioSource};

--- a/crates/engine/src/params.rs
+++ b/crates/engine/src/params.rs
@@ -147,6 +147,7 @@ pub enum TransformSpec {
     BandPass { low_hz: f32, high_hz: f32 },
     Gain { factor: f32 },
     ParametricEq { bands: Vec<EqBand> },
+    SpectralFreeze { frozen: bool },
     Chain(Vec<Self>),
 }
 
@@ -524,6 +525,47 @@ mod tests {
                 assert_eq!(bands[0].band_type, BandType::HighShelf);
             }
             other => panic!("expected SetTransform(ParametricEq), got {other:?}"),
+        }
+    }
+
+    // --- SpectralFreeze TransformSpec roundtrips ---
+
+    #[test]
+    fn transform_spec_spectral_freeze_frozen_roundtrip() {
+        let spec = TransformSpec::SpectralFreeze { frozen: true };
+        let json = roundtrip_json(&spec);
+        assert!(json.contains("SpectralFreeze"));
+        assert!(json.contains("true"));
+    }
+
+    #[test]
+    fn transform_spec_spectral_freeze_unfrozen_roundtrip() {
+        let spec = TransformSpec::SpectralFreeze { frozen: false };
+        let json = roundtrip_json(&spec);
+        assert!(json.contains("SpectralFreeze"));
+        assert!(json.contains("false"));
+    }
+
+    #[test]
+    fn transform_spec_spectral_freeze_in_chain_roundtrip() {
+        let spec = TransformSpec::Chain(vec![
+            TransformSpec::SpectralFreeze { frozen: true },
+            TransformSpec::Gain { factor: 0.5 },
+        ]);
+        roundtrip_json(&spec);
+    }
+
+    #[test]
+    fn param_message_set_spectral_freeze_roundtrip() {
+        let msg = ParamMessage::SetTransform(TransformSpec::SpectralFreeze { frozen: true });
+        let json = serde_json::to_string_pretty(&msg).unwrap();
+        assert!(json.contains("SpectralFreeze"));
+        let recovered: ParamMessage = serde_json::from_str(&json).unwrap();
+        match recovered {
+            ParamMessage::SetTransform(TransformSpec::SpectralFreeze { frozen }) => {
+                assert!(frozen);
+            }
+            other => panic!("expected SetTransform(SpectralFreeze), got {other:?}"),
         }
     }
 }

--- a/crates/engine/src/processor.rs
+++ b/crates/engine/src/processor.rs
@@ -11,8 +11,8 @@ use fourier_audio_io::ring_buffer::{AudioRingBuffer, RingConsumer, RingProducer}
 use fourier_core::overlap_add::{OlaConfig, OverlapAddProcessor};
 use fourier_core::spectral::{detect_peaks, SpectralPeak};
 use fourier_core::transform::{
-    BandPassFilter, HighPassFilter, IdentityTransform, LowPassFilter, ParametricEq, SpectralGain,
-    SpectralTransform, TransformChain,
+    BandPassFilter, HighPassFilter, IdentityTransform, LowPassFilter, ParametricEq, SpectralFreeze,
+    SpectralGain, SpectralTransform, TransformChain,
 };
 
 use crate::error::EngineError;
@@ -214,7 +214,11 @@ impl Drop for Engine {
 }
 
 /// Build a concrete `SpectralTransform` from a `TransformSpec`.
-fn build_transform(spec: &TransformSpec) -> Box<dyn SpectralTransform> {
+fn build_transform(
+    spec: &TransformSpec,
+    sample_rate: f32,
+    hop_size: usize,
+) -> Box<dyn SpectralTransform> {
     match spec {
         TransformSpec::Identity => Box::new(IdentityTransform),
         TransformSpec::LowPass { cutoff_hz } => Box::new(LowPassFilter {
@@ -229,10 +233,13 @@ fn build_transform(spec: &TransformSpec) -> Box<dyn SpectralTransform> {
         }),
         TransformSpec::Gain { factor } => Box::new(SpectralGain { gain: *factor }),
         TransformSpec::ParametricEq { bands } => Box::new(ParametricEq::new(bands.clone())),
+        TransformSpec::SpectralFreeze { frozen } => {
+            Box::new(SpectralFreeze::new(*frozen, sample_rate, hop_size))
+        }
         TransformSpec::Chain(specs) => {
             let mut chain = TransformChain::new();
             for s in specs {
-                chain.push(build_transform(s));
+                chain.push(build_transform(s, sample_rate, hop_size));
             }
             Box::new(chain)
         }
@@ -388,7 +395,7 @@ fn processing_loop(
                 ParamMessage::SetPeakThreshold(t) => params.peak_threshold_db = t,
                 ParamMessage::SetTransform(spec) => {
                     tracing::debug!("Transform changed");
-                    transform = build_transform(&spec);
+                    transform = build_transform(&spec, config.sample_rate, config.hop_size);
                 }
                 ParamMessage::SetSource(spec) => {
                     tracing::debug!("Audio source changed");
@@ -1277,6 +1284,72 @@ mod tests {
                         },
                     ],
                 })
+                .unwrap();
+            engine.set_transform(TransformSpec::Identity).unwrap();
+        }
+
+        thread::sleep(std::time::Duration::from_millis(50));
+        engine.shutdown();
+    }
+
+    // --- SpectralFreeze integration tests ---
+
+    #[test]
+    fn engine_spectral_freeze_produces_output() {
+        let fft_size = 1024;
+        let hop_size = 512;
+        let sample_rate = 44100.0;
+
+        let (engine, io) = Engine::new(sample_rate, fft_size, hop_size).unwrap();
+
+        // Use oscillator source to provide consistent input.
+        engine
+            .set_source(SourceSpec::Oscillator {
+                waveform: fourier_core::WaveformType::Sine,
+                frequency: 440.0,
+                amplitude: 1.0,
+            })
+            .unwrap();
+
+        // Let oscillator run to generate spectral content.
+        thread::sleep(std::time::Duration::from_millis(100));
+
+        // Activate spectral freeze.
+        engine
+            .set_transform(TransformSpec::SpectralFreeze { frozen: true })
+            .unwrap();
+
+        let mut consumer = io.output_consumer;
+        thread::sleep(std::time::Duration::from_millis(200));
+
+        let mut output = vec![0.0_f32; 8192];
+        let n = consumer.pop_slice(&mut output);
+
+        assert!(n > 0, "spectral freeze should produce output");
+        let energy: f32 = output[..n].iter().map(|s| s * s).sum();
+        assert!(
+            energy > 0.0,
+            "spectral freeze output should have nonzero energy"
+        );
+
+        engine.shutdown();
+    }
+
+    #[test]
+    fn engine_spectral_freeze_switch_does_not_panic() {
+        let fft_size = 256;
+        let hop_size = 128;
+        let sample_rate = 44100.0;
+
+        let (engine, _io) = Engine::new(sample_rate, fft_size, hop_size).unwrap();
+
+        // Rapidly toggle freeze on/off — should not panic or deadlock.
+        for _ in 0..10 {
+            engine
+                .set_transform(TransformSpec::SpectralFreeze { frozen: true })
+                .unwrap();
+            engine
+                .set_transform(TransformSpec::SpectralFreeze { frozen: false })
                 .unwrap();
             engine.set_transform(TransformSpec::Identity).unwrap();
         }


### PR DESCRIPTION
## Summary

- Implements `SpectralFreeze` struct in `fourier-core` implementing `SpectralTransform`
- When activated (`frozen: true`), captures current spectral frame magnitudes and phases
- While frozen, outputs captured spectrum instead of live input
- Smooth ~75ms crossfade on toggle via linear interpolation in complex domain
- Adds `TransformSpec::SpectralFreeze { frozen: bool }` variant with serde support
- Re-exports `SpectralFreeze` from `fourier-core` and `fourier-engine` crate roots
- Updates ROADMAP.md to mark #11 as complete

## Test plan

- [x] 8 unit tests in `fourier-core`: capture, stability, pass-through, smooth crossfade, toggle off, getters, name, empty spectrum
- [x] 4 serde roundtrip tests in `fourier-engine`: frozen/unfrozen, in-chain, param message
- [x] 2 engine integration tests: freeze with oscillator source, rapid toggle
- [x] All 225 workspace tests pass
- [x] Clippy clean (pedantic + nursery)
- [x] `cargo fmt` clean

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)